### PR TITLE
fix: resolve Rust edition2024 compatibility issue in Docker build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64ct",
  "chrono",
  "jsonwebtoken",
  "serde",
@@ -184,9 +185,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ jsonwebtoken = "9.0"
 # candle-core = "0.7"  # TODO: Fix version conflicts and re-enable
 tracing = "0.1"
 tracing-subscriber = "0.3"
+
+# Force older version of base64ct to avoid edition2024 requirement
+base64ct = "=1.6.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.75 as builder
+FROM rust:1.83 as builder
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ COPY Cargo.toml Cargo.lock ./
 # Create a dummy main.rs to cache dependencies
 RUN mkdir src && echo "fn main() {}" > src/main.rs && echo "" > src/lib.rs
 
-# Build dependencies
+# Build dependencies (this will generate Cargo.lock)
 RUN cargo build --release && rm src/*.rs
 
 # Copy source code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build: .


### PR DESCRIPTION
- Update Rust version from 1.75 to 1.83 in Dockerfile
- Add base64ct version constraint (=1.6.0) to avoid edition2024 requirement
- Remove version specification from docker-compose.yml for modern Docker Compose
- Update Cargo.lock with downgraded base64ct dependency

This resolves the Docker build failure caused by base64ct 1.8.0 requiring unstabilized edition2024 features. The constraint forces use of compatible base64ct 1.6.0 while maintaining functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)